### PR TITLE
use DashMap instead of Mutex<HashSet> to reduce lock contention

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["intern", "interner", "interning"]
 
 [dependencies]
+dashmap = "3.11"
 lazy_static = "1.4"
 serde = "1.0"
 state = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arc-interner"
 description = "An interner that deallocates unused values"
 homepage = "https://github.com/ryzhyk/arc-interner"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Leonid Ryzhyk <lryzhyk@vmware.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This crate is a fork of [David Roundy's](https://github.com/droundy/)
 [`internment` crate](https://crates.io/crates/internment).
 It provides an alternative implementation of the `internment::ArcIntern`
 type.  It inherits David's high-level design and API; however it is built
-completely on Rust's standard `Arc` and `Mutex` types and does not contain
+completely on Rust's standard `Arc` type and the
+[`dashmap` crate](https://crates.io/crates/dashmap) and does not contain
 any unsafe code.
 
 Interning reduces the memory footprint of an application by storing
@@ -30,15 +31,12 @@ choices:
   some CPU and memory overhead (due to storing and maintaining an
   atomic counter).
 - Multithreading.  A single pool of interned objects is shared by all
-  threads in the program.  This pool is protected by a mutex that is
-  acquired every time an object is being interned or a reference to
-  an interned object is being dropped.  Althgough Rust mutexes are fairly
-  cheap when there is no contention, you may see a significant drop in
-  performance under contention.
+  threads in the program.  The pool is implemented as a `DashMap` for
+  safe concurrent access and low contention.
 - Not just strings: this library allows interning any data type that
   satisfies the `Eq + Hash + Send + Sync` trait bound.
-- Safe: this library is built on `Arc` and `Mutex` types from the Rust
-  standard library and does not contain any unsafe code.
+- Safe: this library is built on `Arc` and `DashMap` types
+  and does not contain any unsafe code.
 
 # Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,21 @@ mod tests {
     }
 
     #[derive(Eq, PartialEq, Hash)]
+    pub struct TestStruct2(String,u64);
+
+    #[test]
+    fn sequential() {
+        for _i in 0..10_000 {
+            let mut interned = Vec::with_capacity(100);
+            for j in 0..100 {
+                interned.push(ArcIntern::new(TestStruct2("foo".to_string(), j)));
+            }
+        }
+
+        assert_eq!(ArcIntern::<TestStruct2>::num_objects_interned(), 0);
+    }
+
+    #[derive(Eq, PartialEq, Hash)]
     pub struct TestStruct(String,u64);
 
     // Quickly create and destroy a small number of interned objects from
@@ -279,7 +294,7 @@ mod tests {
     #[test]
     fn multithreading1() {
         let mut thandles = vec![];
-        for _i in 0..3 {
+        for _i in 0..10 {
             thandles.push(thread::spawn(|| {
                 for _i in 0..100_000 {
                     let _interned1 = ArcIntern::new(TestStruct("foo".to_string(), 5));


### PR DESCRIPTION
I found that in my multithreaded use case ArcIntern was heavily contended on the single mutex per interned type.

Switching from Mutex<HashMap> to DashMap reduced contention as DashMap shards the keys under a number of mutexes. 

Benefits will obviously will depend on your use case, but for me the time spent in ArcIntern::new or ArcIntern::drop has been reduced to between half and one-third of the original time.