### PR TITLE
Use OnceCell<DashMap> instead of the state crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,5 @@ keywords = ["intern", "interner", "interning"]
 
 [dependencies]
 dashmap = "3.11"
-lazy_static = "1.4"
+once_cell = "1.3"
 serde = "1.0"
-state = "0.4"


### PR DESCRIPTION
This change switches to use a OnceCell<DashMap> instead of state::Container and lazy_static.

On my contended use-case this performs between 2 and 3 times faster than state::Container did. If future DashMap versions become truly lockless then it should improve further.

Because ArcIntern can't freeze() its state::Container, the state::Container itself was becoming a source of contention. When contended the state::Container spinlocks use a lot of cpu.  The DashMap can still become contended, but it's sharded reader/writer locks degrade more gracefully than the state::Container spinlocks.
