### PR TITLE
Fix leak of underlying data hash count

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,13 @@ impl<T: Eq + Hash + Send + Sync + Default + 'static> Default for ArcIntern<T> {
 /// hash of the pointer with hash of the data itself.
 impl<T: Eq + Hash + Send + Sync> Hash for ArcIntern<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        Arc::into_raw(self.arc.clone()).hash(state);
+        // The clone in this function makes the Arc::strong_count
+        // temporarily increase.  This does not break drop as count
+        // is already >2 if another thread is calling hash.
+        let raw = Arc::into_raw(self.arc.clone());
+        raw.hash(state);
+        // Don't leak increase of count from the clone() above
+        unsafe { Arc::from_raw(raw) };
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,7 @@ impl<'de, T: Eq + Hash + Send + Sync + 'static + Deserialize<'de>> Deserialize<'
 #[cfg(test)]
 mod tests {
     use crate::ArcIntern;
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::thread;
 
@@ -306,8 +307,11 @@ mod tests {
                 let drop_check = drop_check.clone();
                 move || {
                     for _i in 0..100_000 {
-                        let _interned1 = ArcIntern::new(TestStruct("foo".to_string(), 5, drop_check.clone()));
+                        let interned1 = ArcIntern::new(TestStruct("foo".to_string(), 5, drop_check.clone()));
                         let _interned2 = ArcIntern::new(TestStruct("bar".to_string(), 10, drop_check.clone()));
+                        let mut m = HashMap::new();
+                        // force some hashing
+                        m.insert(interned1, ());
                     }
                 }
             });


### PR DESCRIPTION
The ArcIntern hash() function had to Arc::into_raw without a balancing Arc::from_raw

This PR 
  - Adds a test of the count of underlying drop's done  to the multithreading test
  - Shows that calling hash was causing not enough drops of underlying data and thus a leak
  - Fixes hash so that it doesn't trigger a leak

