### PR TITLE
update dashmap dependency to pick up 4.x releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ readme = "README.md"
 keywords = ["intern", "interner", "interning"]
 
 [dependencies]
-dashmap = "3.11"
+dashmap = "4.0.2"
 once_cell = "1.3"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["intern", "interner", "interning"]
 
 [dependencies]
+ahash = "0.3.8"
 dashmap = "4.0.2"
 once_cell = "1.3"
 serde = "1.0"


### PR DESCRIPTION
dashmap 4.x ended up as a maintenence release rather than the lockless redesign they planned so this is not super exciting, but might as well keep current

tested with cargo test