### PR TITLE
Forward hash to inner type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ impl<T: Eq + Hash + Send + Sync> Drop for ArcIntern<T> {
                 // If the reference count is 2, then the only two remaining references
                 // to this value are held by `self` and the hashmap and we can safely
                 // deallocate the value.
-                Arc::strong_count(&k) == 2
+                Arc::strong_count(k) == 2
             });
         }
     }
@@ -232,7 +232,7 @@ impl<'de, T: Eq + Hash + Send + Sync + 'static + Deserialize<'de>> Deserialize<'
     for ArcIntern<T>
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        T::deserialize(deserializer).map(|x: T| Self::new(x))
+        T::deserialize(deserializer).map(Self::new)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,14 +182,11 @@ impl<T: Eq + Hash + Send + Sync + Default + 'static> Default for ArcIntern<T> {
     }
 }
 
-/// The hash implementation returns the hash of the pointer
-/// value, not the hash of the value pointed to.  This should
-/// be irrelevant, since there is a unique pointer for every
-/// value, but it *is* observable, since you could compare the
-/// hash of the pointer with hash of the data itself.
 impl<T: Eq + Hash + Send + Sync> Hash for ArcIntern<T> {
+    // `Hash` implementation must be equivalent for owned and borrowed values.
     fn hash<H: Hasher>(&self, state: &mut H) {
-        Arc::as_ptr(&self.arc).hash(state);
+        let borrow: &T = self.borrow();
+        borrow.hash(state);
     }
 }
 


### PR DESCRIPTION
This addresses issue #13.

We used to hash pointers instead of values, as for interned values hash
equality is equivalent to value equality.  This is wrong in multiple
ways.  First, this violates the requirement that `Hash` must
be equivalent in owned and borrowed values.   Second, if an interned
value is garbage collected and then created again between two `hash()`
invocations, they will return different values.

cc: @ahornby 